### PR TITLE
fix: Client receive DHCP offer

### DIFF
--- a/Network/Network/Network.java
+++ b/Network/Network/Network.java
@@ -35,12 +35,13 @@ public class Network {
         nodes.add(node);
     }
 
-    public void broadcast(DataUnit data) {
+    public void broadcast(DataUnit data, Node sender) {
         if(!(data instanceof EthernetFrame) || ((EthernetFrame) data).getIPPacket().getProtocol() != 17) {
             return;
         }
 
         for (Node node : nodes) {
+            if(node.equals(sender)) continue;
             node.receive(data);
         }
     }

--- a/Network/Node/End/Computer.java
+++ b/Network/Node/End/Computer.java
@@ -15,6 +15,20 @@ public class Computer extends Node {
         this.network = network;
     }
 
+    @Override
+    public void receive(DataUnit data) {
+        if (!(data instanceof EthernetFrame)) return;
+
+        EthernetFrame frame = (EthernetFrame) data;
+        String destinationMAC = frame.getDestinationMAC();
+
+        if (!destinationMAC.equals(this.MACAddress)) {
+            // 내 MAC 주소가 아니면 무시
+            return;
+        }
+        super.receive(data);
+    }
+
     public void setIpAddress(String ipAddress) {
         this.ipAddress = ipAddress;
     }
@@ -35,10 +49,11 @@ public class Computer extends Node {
         UDPDatagram.UDPHeader header = new UDPDatagram.UDPHeader(sourcePort, destinationPort, length, checksum);
         UDPDatagram udpDatagram = new UDPDatagram(header, payload);
 
+        // protocol 17: UDP, 6: TCP
         IPPacket ipPacket = new IPPacket("0.0.0.0", "255.255.255.255", 17, udpDatagram);
         EthernetFrame frame = new EthernetFrame("FF:FF:FF:FF:FF:FF", MACAddress, 0x0800, ipPacket);
 
-        network.broadcast(frame);
+        network.broadcast(frame, this);
     }
 
     public static Builder builder() {

--- a/Network/Node/End/DHCPServer.java
+++ b/Network/Node/End/DHCPServer.java
@@ -24,6 +24,7 @@ public class DHCPServer extends Node {
     private DHCPServer(String MACAddress, String ipAddress, Network network) throws UnknownHostException {
         this.MACAddress = MACAddress;
         this.ipAddress = ipAddress;
+        this.network = network;
         intIpAddress = IPUtil.ipToInt(ipAddress);
         startIP = network.getSubnetAddress() + 1;
         endIP = (network.getSubnetAddress() | (~network.getSubnetMask())) - 1;
@@ -47,7 +48,7 @@ public class DHCPServer extends Node {
         return -1;
     }
 
-    // TODO.
+    // TODO. 회수한 ip 관리 로직 추가
     private void cleanExpiredIPs() {
         for(Map.Entry<Integer, Long> entry : allocatedIP.entrySet()) {
             if(entry.getValue() < System.currentTimeMillis()) {
@@ -84,6 +85,7 @@ public class DHCPServer extends Node {
         }
     }
 
+    // todo. DNS 구현 시 DNS 주소 추가
     private void offerDHCP(String clientMAC) {
         String payload = "Client MAC=" + clientMAC +
                 ",Your IP=" + findAllocatableIP() +
@@ -102,9 +104,9 @@ public class DHCPServer extends Node {
 
         UDPDatagram.UDPHeader header = new UDPDatagram.UDPHeader(sourcePort, destinationPort, length, checksum);
         UDPDatagram datagram = new UDPDatagram(header, payload);
-        IPPacket ipPacket = new IPPacket(ipAddress, "255.255.255.255", 6, datagram);
-        EthernetFrame frame = new EthernetFrame("", MACAddress, 0x0800, ipPacket);
-        network.broadcast(frame);
+        IPPacket ipPacket = new IPPacket(ipAddress, "255.255.255.255", 17, datagram);
+        EthernetFrame frame = new EthernetFrame(clientMAC, MACAddress, 0x0800, ipPacket);
+        network.broadcast(frame, this);
     }
 
     public static Builder builder() {

--- a/Network/Node/Node.java
+++ b/Network/Node/Node.java
@@ -8,7 +8,9 @@ public abstract class Node {
     protected String MACAddress;
     protected Network network;
 
+    // todo. EthernetFrame, IPPacket, TransportDataUnit 모두 처리할 수 있도록
+    // todo. protocol 확인해서 UDP / TCP로 분기하는 로직 추가
     public void receive(DataUnit data) {
-        System.out.println(getClass().getName() + " " + ipAddress + " received " + data.toString());
+        System.out.println(getClass().getName() + " " + ipAddress + " received\n" + data.toString()+"\n");
     }
 }

--- a/Network/Simulation/DHCPTest.java
+++ b/Network/Simulation/DHCPTest.java
@@ -10,14 +10,17 @@ public class DHCPTest {
         DHCPServer dhcpServer = DHCPServer.builder()
                 .ip("192.168.1.10")
                 .mac("00-1A-2B-3C-4D-5E")
-                .network(network).build();
+                .network(network)
+                .build();
         network.addNode(dhcpServer);
 
         Computer client = Computer.builder()
                 .mac("01-2A-3B-4C-5D-6E")
-                .network(network).build();
-
+                .network(network)
+                .build();
         network.addNode(client);
+
         client.discoverDHCPServer();
+        Thread.sleep(100);
     }
 }


### PR DESCRIPTION
DHCP offer 단계에서 DHCP server가 offer 메시지를 protocol 17(UDP)로 전송해야 하는데
 6(TCP)로 전송하여 client에서 data를 식별하지 못하는 에러를 수정했습니다.