### PR TITLE
refactor: Extract common receive logic and add protocol dispatching

### DIFF
--- a/Network/Node/End/DHCPServer.java
+++ b/Network/Node/End/DHCPServer.java
@@ -60,7 +60,11 @@ public class DHCPServer extends Node {
     @Override
     public void receive(DataUnit data) {
         super.receive(data);
-        EthernetFrame frame = (EthernetFrame) data;
+    }
+
+    @Override
+    protected void handleUDP(DataUnit dataUnit) {
+        EthernetFrame frame = (EthernetFrame) dataUnit;
         String destinationMAC = frame.getDestinationMAC();
         String sourceMAC = frame.getSourceMAC();
 

--- a/Network/Node/Node.java
+++ b/Network/Node/Node.java
@@ -1,16 +1,70 @@
 package Network.Node;
 
+import Network.DataUnit.DataLinkLayer.EthernetFrame;
 import Network.DataUnit.DataUnit;
+import Network.DataUnit.NetworkLayer.IPPacket;
+import Network.DataUnit.TransportLayer.TransportDataUnit;
 import Network.Network.Network;
+import Network.Util.IPUtil;
 
 public abstract class Node {
     protected String ipAddress;
     protected String MACAddress;
     protected Network network;
 
-    // todo. EthernetFrame, IPPacket, TransportDataUnit 모두 처리할 수 있도록
-    // todo. protocol 확인해서 UDP / TCP로 분기하는 로직 추가
     public void receive(DataUnit data) {
-        System.out.println(getClass().getName() + " " + ipAddress + " received\n" + data.toString()+"\n");
+        System.out.println(getClass().getName() + " " + ipAddress + " received\n" + data + "\n");
+
+        IPPacket ipPacket = null;
+
+        // L2 계층: EthernetFrame 처리
+        if (data instanceof EthernetFrame frame) {
+            if (!isDestinedToMeMAC(frame.getDestinationMAC())) return;
+            ipPacket = frame.getIPPacket();
+        } else if (data instanceof IPPacket packet) {
+            ipPacket = packet;
+        } else {
+            return;
+        }
+
+        // L3 계층: IP 확인
+        if (!isDestinedToMeIP(ipPacket.getDestinationIP())) return;
+
+        // L4 계층: 프로토콜 분기
+        switch (ipPacket.getProtocol()) {
+            case 6 -> handleTCP(data);
+            case 17 -> handleUDP(data);
+            default -> System.out.println("Unknown protocol: " + ipPacket.getProtocol());
+        }
+    }
+
+    protected boolean isDestinedToMeMAC(String destMAC) {
+        return destMAC.equals(this.MACAddress) || destMAC.equals("FF:FF:FF:FF:FF:FF");
+    }
+
+    protected boolean isDestinedToMeIP(String destIP) {
+        return destIP.equals(this.ipAddress)
+                || destIP.equals("255.255.255.255")
+                || isSubnetBroadcast(destIP);
+    }
+
+    private boolean isSubnetBroadcast(String destIP) {
+        try {
+            int dest = IPUtil.ipToInt(destIP);
+            int subnetAddr = network.getSubnetAddress();
+            int subnetMask = network.getSubnetMask();
+            int broadcast = subnetAddr | (~subnetMask);
+            return dest == broadcast;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    protected void handleUDP(DataUnit dataUnit) {
+
+    }
+
+    protected void handleTCP(DataUnit dataUnit) {
+
     }
 }


### PR DESCRIPTION
receive() 로직을 각 노드에서 중복 구현하고 있어, 이를 상위 클래스인 Node로 이동하고 공통 처리하도록 리팩토링했습니다.

* EthernetFrame, IPPacket 기반의 수신 로직을 Node.receive()에서 공통 처리합니다.

* 목적지 MAC/IP 확인 후 프로토콜 번호에 따라 handleUDP(), handleTCP()로 분기합니다.

* 하위 클래스는 필요한 프로토콜에 대해 handleUDP() 또는 handleTCP()를 오버라이드하여 동작을 구현할 수 있습니다.

* DHCP 서버 등 일부 프로토콜에서는 datalink 계층 정보가 필요하므로, EthernetFrame을 유지한 구조로 처리합니다.