### PR TITLE
refactor: improve toString formatting for EthernetFrame and IPPacket

### DIFF
--- a/Network/DataUnit/DataLinkLayer/EthernetFrame.java
+++ b/Network/DataUnit/DataLinkLayer/EthernetFrame.java
@@ -18,7 +18,12 @@ public class EthernetFrame implements DataUnit {
 
     @Override
     public String toString() {
-        return "EthernetFrame [DA=" + destinationMAC + ", SA=" + sourceMAC + ", EtherType=" + etherType + ", IPPacket=" + ipPacket + "]";
+        return "EthernetFrame {\n" +
+                "\tDestination MAC: " + destinationMAC + "\n" +
+                "\tSource MAC: " + sourceMAC + "\n" +
+                "\tEtherType: " + etherType + "\n" +
+                "\t" + ipPacket.toString().replace("\n", "\n\t") + // IPPacket 내부도 들여쓰기
+                "\n}";
     }
 
     public String getDestinationMAC() {

--- a/Network/DataUnit/NetworkLayer/IPPacket.java
+++ b/Network/DataUnit/NetworkLayer/IPPacket.java
@@ -18,7 +18,12 @@ public class IPPacket implements DataUnit {
 
     @Override
     public String toString() {
-        return "IPPacket [SIP=" + sourceIP + ", DIP=" + destinationIP + ", Protocol=" + protocol + ", TransportSegment=" + transportDataUnit + "]";
+        return "IPPacket {\n" +
+                "\tSource IP: " + sourceIP + "\n" +
+                "\tDestination IP: " + destinationIP + "\n" +
+                "\tProtocol: " + protocol + "\n" +
+                "\tTransportSegment: " + transportDataUnit.toString().replace("\n", "\n\t") +
+                "\n}";
     }
 
     public String getSourceIP() {

--- a/Network/DataUnit/TransportLayer/UDPDatagram.java
+++ b/Network/DataUnit/TransportLayer/UDPDatagram.java
@@ -9,8 +9,15 @@ public class UDPDatagram implements TransportDataUnit {
         this.payload = payload;
     }
 
+    @Override
     public String toString() {
-        return payload;
+        return "UDPDatagram {\n" +
+                "\tSource Port: " + udpHeader.sourcePort + "\n" +
+                "\tDestination Port: " + udpHeader.destinationPort + "\n" +
+                "\tLength: " + udpHeader.length + "\n" +
+                "\tChecksum: " + udpHeader.checksum + "\n" +
+                "\tPayload: " + payload.replace(",", ",\n\t\t") +
+                "\n}";
     }
 
     public static class UDPHeader {


### PR DESCRIPTION
EthernetFrame [DA=01-2A-3B-4C-5D-6E, SA=00-1A-2B-3C-4D-5E, EtherType=2048, IPPacket=IPPacket [SIP=192.168.1.10, DIP=255.255.255.255, Protocol=17, TransportSegment=Client MAC=01-2A-3B-4C-5D-6E,Your IP=-1062731519,Subnet Mask=255.255.255.0,Router=192.168.1.1,DNS=DNS 서버 IP 주소,IP Lease Time=60000,DHCP Message Type=DHCPOFFER,DHCP Server Identifier=192.168.1.10]]

이렇게 한 줄로 나오던 DataUnit.toString 에 들여쓰기를 반영하여  가독성을 높였습니다.

Network.Node.End.DHCPServer 192.168.1.10 received
EthernetFrame {
	Destination MAC: FF:FF:FF:FF:FF:FF
	Source MAC: 01-2A-3B-4C-5D-6E
	EtherType: 2048
	IPPacket {
		Source IP: 0.0.0.0
		Destination IP: 255.255.255.255
		Protocol: 17
		TransportSegment: UDPDatagram {
			Source Port: 68
			Destination Port: 67
			Length: 67
			Checksum: 0
			Payload: DHCP Message Type=DHCPDISCOVER,
				Client MAC=01-2A-3B-4C-5D-6E
		}
	}
}