### PR TITLE
feat: Implement DHCPACK handling in server and client

### DIFF
--- a/Network/Constants/DHCPMessageType.java
+++ b/Network/Constants/DHCPMessageType.java
@@ -1,0 +1,15 @@
+package Network.Constants;
+
+import java.util.Optional;
+
+public enum DHCPMessageType {
+	DHCPDISCOVER, DHCPOFFER, DHCPREQUEST, DHCPACK, DHCPNACK;
+
+	public static Optional<DHCPMessageType> from(String value) {
+		try {
+			return Optional.of(valueOf(value.trim()));
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+}


### PR DESCRIPTION
## 개요
서버가 DHCPREQUEST에 대해 DHCPACK 메시지를 전송하고, 클라이언트가 이를 수신하여 IP를 설정하도록 구현했습니다.

## 주요 변경 사항
- 서버: `ackDHCP()` 메서드 구현
- Flags 값에 따라 broadcast/unicast 분기
- 클라이언트: DHCPACK 수신 시 `setIpAddress()` 호출
- Payload 구조에 `Flags`, `Requested IP Address` 포함

## 테스트
- Wireshark 로그 시뮬레이터에서 DORA 순서대로 메시지 흐름 확인
- ACK 이후 클라이언트가 IP를 올바르게 설정하는지 확인함

## 기타
- unicast 구현은 추후 예정
